### PR TITLE
Add support to conditionally step down from root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .python-version
 .vscode
+.idea

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
     "docker_base_image": "ubuntu:20.04",
     "vendor_base": "debian",
     "dockerfile_extra_content": "",
-    "use_non_root_user": "True",
+    "use_non_root_user": true,
     "lib_dir": "lib{% if cookiecutter.vendor_base == 'rhel' %}64{% endif %}",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,7 @@
     "docker_base_image": "ubuntu:20.04",
     "vendor_base": "debian",
     "dockerfile_extra_content": "",
+    "use_non_root_user": "True",
     "lib_dir": "lib{% if cookiecutter.vendor_base == 'rhel' %}64{% endif %}",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -27,7 +27,7 @@ RUN pacman -Syu --noconfirm \
 RUN python3 -m ensurepip
 {%- endif %}
 
-{% if cookiecutter.use_non_root_user == "True" -%}
+{% if cookiecutter.use_non_root_user -%}
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
@@ -48,7 +48,7 @@ RUN dnf install -y rpm-build gcc make pkgconf-pkg-config ${SYSTEM_REQUIRES}
 RUN pacman -Syu  --noconfirm base-devel ${SYSTEM_REQUIRES}
 {%- endif %}
 
-{% if cookiecutter.use_non_root_user == "True" -%}
+{% if cookiecutter.use_non_root_user -%}
 # Use the brutus user for operations in the container
 USER brutus
 {%- endif %}

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -3,7 +3,7 @@ FROM {{ cookiecutter.docker_base_image }}
 # Set the working directory
 WORKDIR /app
 
-{% if cookiecutter.vendor_base == "debian" %}
+{% if cookiecutter.vendor_base == "debian" -%}
 # Make sure installation of tzdata is non-interactive
 ENV DEBIAN_FRONTEND="noninteractive"
 
@@ -13,19 +13,21 @@ RUN apt-get update -y && \
         python{{ cookiecutter.python_version|py_tag }}-dev \
         python{{ cookiecutter.python_version|py_tag }}-venv \
         python{{ cookiecutter.python_version|py_tag }}-pip
-{% elif cookiecutter.vendor_base == "rhel" %}
+{%- elif cookiecutter.vendor_base == "rhel" -%}
 # Install System python
 RUN dnf install -y \
     python{{ cookiecutter.python_version|py_tag }}-devel \
     python{{ cookiecutter.python_version|py_tag }}-pip
-{% elif cookiecutter.vendor_base == "arch" %}
+{%- elif cookiecutter.vendor_base == "arch" -%}
 # Install System python
 RUN pacman -Syu --noconfirm \
     python{{ cookiecutter.python_version|py_tag }}
 
 # Ensure pip is available
 RUN python3 -m ensurepip
-{% endif %}
+{%- endif %}
+
+{% if cookiecutter.use_non_root_user == "True" -%}
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
@@ -34,19 +36,22 @@ ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
     mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+{%- endif %}
 
 # As root, install system packages required by app
 ARG SYSTEM_REQUIRES
-{% if cookiecutter.vendor_base == "debian" %}
+{% if cookiecutter.vendor_base == "debian" -%}
 RUN apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES}
-{% elif cookiecutter.vendor_base == "rhel" %}
+{%- elif cookiecutter.vendor_base == "rhel" -%}
 RUN dnf install -y rpm-build gcc make pkgconf-pkg-config ${SYSTEM_REQUIRES}
-{% elif cookiecutter.vendor_base == "arch" %}
+{%- elif cookiecutter.vendor_base == "arch" -%}
 RUN pacman -Syu  --noconfirm base-devel ${SYSTEM_REQUIRES}
-{% endif %}
+{%- endif %}
 
+{% if cookiecutter.use_non_root_user == "True" -%}
 # Use the brutus user for operations in the container
 USER brutus
+{%- endif %}
 
 # ========== START USER PROVIDED CONTENT ==========
 {{ cookiecutter.dockerfile_extra_content }}


### PR DESCRIPTION
## Changes
- Adds support to conditionally introduce a step down user (i.e. "brutus") in images created from the Dockerfile
- This is required for Docker Desktop and rootless Docker as outlined in beeware/briefcase#1083

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase/
BRIEFCASE_REF: docker-desktop

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
