### PR TITLE
Assign `brutus` as owner of `/home/brutus/.cache`

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -31,11 +31,12 @@ RUN python3 -m ensurepip
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
 # Use --non-unique to avoid problems when the UID:GID of the host user
 # collides with entries provided by the Docker container.
+# Create Briefcase data dir so Docker's bind mount doesn't assign root as owner of .cache at runtime.
 ARG HOST_UID
 ARG HOST_GID
 RUN groupadd --non-unique --gid $HOST_GID briefcase && \
     useradd --non-unique --uid $HOST_UID --gid $HOST_GID brutus --home /home/brutus && \
-    mkdir -p /home/brutus && chown brutus:briefcase /home/brutus
+    mkdir -p /home/brutus/.cache/briefcase && chown -R brutus:briefcase /home/brutus
 {%- endif %}
 
 # As root, install system packages required by app


### PR DESCRIPTION
## Changes
- Since the Briefcase data directory is bind mounted in to the `.cache` directory when `.cache` does not yet exist, Docker assigns `root` as its owner and this can create spurious warnings for applications trying to use `.cache` while building/installing.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
