### PR TITLE
Install the latest version of `pip`

### DIFF
--- a/tests/apps/verify-pygame/pyproject.toml
+++ b/tests/apps/verify-pygame/pyproject.toml
@@ -8,6 +8,7 @@ author = 'Brutus'
 author_email = "contact@beeware.org"
 
 [tool.briefcase.app.verify-pygame]
+template = "../../.."
 formal_name = "Hello Pygame"
 description = "A Pygame test app"
 long_description = """More details about the app should go here.

--- a/tests/apps/verify-toga/pyproject.toml
+++ b/tests/apps/verify-toga/pyproject.toml
@@ -8,6 +8,7 @@ author = "Brutus"
 author_email = "contact@beeware.org"
 
 [tool.briefcase.app.verify-toga]
+template = "../../.."
 formal_name = "Hello Toga"
 description = "A Toga test app"
 icon = "src/verify_toga/resources/verify-toga"
@@ -31,13 +32,12 @@ system_requires = [
 ]
 
 system_runtime_requires = [
-    # Needed to provide GTK
-    "libgtk-3-0",
-    # Needed to provide GI bindings to GTK
-    "libgirepository-1.0-1",
+    # Needed to provide GTK and its GI bindings
     "gir1.2-gtk-3.0",
+    "libgirepository-1.0-1",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra-gtk3-module",
     # Needed to provide WebKit2 at runtime
-    # "libwebkit2gtk-4.0-37",
     # "gir1.2-webkit2-4.0",
 ]
 
@@ -50,24 +50,29 @@ system_requires = [
 ]
 
 system_runtime_requires = [
+    # Needed to support Python bindings to GTK
+    "gobject-introspection",
     # Needed to provide GTK
     "gtk3",
+    # Dependencies that GTK looks for at runtime
+    "libcanberra-gtk3",
     # Needed to provide WebKit2 at runtime
     # "webkit2gtk3",
 ]
 
 [tool.briefcase.app.verify-toga.linux.system.arch]
 system_requires = [
-    # Needed to provide GTK
-    "gtk3",
-     # Needed to compile pycairo wheel
+    # Needed to compile pycairo wheel
     "cairo",
     # Needed to compile PyGObject wheel
     "gobject-introspection",
-    # Dependencies that GTK looks for at runtime, that need to be
-    # in the build environment
+    # Runtime dependencies that need to exist so that the
+    # Arch package passes final validation.
+    # Needed to provide GTK
+    "gtk3",
+    # Dependencies that GTK looks for at runtime
     "libcanberra",
-    # Needed to provide WebKit2 at runtime
+    # Needed to provide WebKit2
     # "webkit2gtk",
 ]
 

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -3,6 +3,10 @@ FROM {{ cookiecutter.docker_base_image }}
 # Set the working directory
 WORKDIR /app
 
+# Disable pip's warnings
+ENV PIP_ROOT_USER_ACTION=ignore \
+    PIP_NO_WARN_SCRIPT_LOCATION=0
+
 {% if cookiecutter.vendor_base == "debian" -%}
 # Make sure installation of tzdata is non-interactive
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -52,6 +56,9 @@ RUN pacman -Syu  --noconfirm base-devel ${SYSTEM_REQUIRES}
 # Use the brutus user for operations in the container
 USER brutus
 {%- endif %}
+
+# Install latest pip for user
+RUN python3 -m pip install --user --upgrade pip
 
 # ========== START USER PROVIDED CONTENT ==========
 {{ cookiecutter.dockerfile_extra_content }}

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -8,8 +8,8 @@ ENV PIP_ROOT_USER_ACTION=ignore \
     PIP_NO_WARN_SCRIPT_LOCATION=0
 
 {% if cookiecutter.vendor_base == "debian" -%}
-# Make sure installation of tzdata is non-interactive
-ENV DEBIAN_FRONTEND="noninteractive"
+# Run apt non-interactively; use ARG so this only applies while building the image
+ARG DEBIAN_FRONTEND="noninteractive"
 
 # Install System python
 RUN apt-get update -y && \
@@ -30,6 +30,13 @@ RUN pacman -Syu --noconfirm \
 # Ensure pip is available
 RUN python3 -m ensurepip
 {%- endif %}
+
+# Upgrade pip et alia
+# PEP 668 allows distros to mark the system Python as "externally managed". With this
+# configuration, `pip install` will error when using the system Python. This setting
+# ignores this configuration in the distro and allows for installing the latest pip.
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 \
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 {% if cookiecutter.use_non_root_user -%}
 # Ensure Docker user UID:GID matches host user UID:GID (beeware/briefcase#403)
@@ -56,9 +63,6 @@ RUN pacman -Syu  --noconfirm base-devel ${SYSTEM_REQUIRES}
 # Use the brutus user for operations in the container
 USER brutus
 {%- endif %}
-
-# Install latest pip for user
-RUN python3 -m pip install --user --upgrade pip
 
 # ========== START USER PROVIDED CONTENT ==========
 {{ cookiecutter.dockerfile_extra_content }}


### PR DESCRIPTION
## Changes
- Given that a distro provided `pip` may be quite old, install the latest `pip` inside the image
- To accommodate [PEP 668](https://peps.python.org/pep-0668/), the latest `pip` is installed using `PIP_BREAK_SYSTEM_PACKAGES=1`
- Update Toga and Pygame tests so they use the local repo for CI instead of downloading the current one
- Aligned the `pyproject.toml` configs for the test apps with current `briefcase-template`


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
