### PR TITLE
Fix `pip` install for Arch support for PEP 668

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -14,21 +14,19 @@ ARG DEBIAN_FRONTEND="noninteractive"
 # Install System python
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        python{{ cookiecutter.python_version|py_tag }}-dev \
-        python{{ cookiecutter.python_version|py_tag }}-venv \
-        python{{ cookiecutter.python_version|py_tag }}-pip
+      python{{ cookiecutter.python_version|py_tag }}-dev \
+      python{{ cookiecutter.python_version|py_tag }}-venv \
+      python{{ cookiecutter.python_version|py_tag }}-pip
 {%- elif cookiecutter.vendor_base == "rhel" -%}
 # Install System python
 RUN dnf install -y \
-    python{{ cookiecutter.python_version|py_tag }}-devel \
-    python{{ cookiecutter.python_version|py_tag }}-pip
+      python{{ cookiecutter.python_version|py_tag }}-devel \
+      python{{ cookiecutter.python_version|py_tag }}-pip
 {%- elif cookiecutter.vendor_base == "arch" -%}
 # Install System python
 RUN pacman -Syu --noconfirm \
-    python{{ cookiecutter.python_version|py_tag }}
-
-# Ensure pip is available
-RUN python3 -m ensurepip
+      python{{ cookiecutter.python_version|py_tag }} \
+      python-pip
 {%- endif %}
 
 # Upgrade pip et alia


### PR DESCRIPTION
## Changes
- PEP 668 allows distros to explicitly declare system-installed Python packages as "externally managed" and prevent `pip` from updating them directly instead of through the distro's package manager.
- To accommodate this, `pip` is now installed with `pacman` instead of `ensurepip` and is updated via the [previous implementation](https://github.com/beeware/briefcase-linux-system-template/pull/8) of `PIP_BREAK_SYSTEM_PACKAGES`.

## Notes
- First discovered in CI for beeware/briefcase#1417

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
