### PR TITLE
Bump pre-commit-hooks from v4.4.0 to v4.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         exclude: "{{ cookiecutter.format }}/manifest.yml"


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from v4.4.0 to v4.5.0 and ran the update against the repo.