### PR TITLE
Ensure `apt` is always up-to-date before installing

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -44,7 +44,8 @@ RUN PIP_BREAK_SYSTEM_PACKAGES=1 \
 # As root, install system packages required by app
 ARG SYSTEM_REQUIRES
 {% if cookiecutter.vendor_base == "debian" -%}
-RUN apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES}
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y build-essential ${SYSTEM_REQUIRES}
 {%- elif cookiecutter.vendor_base == "rhel" -%}
 RUN dnf install -y rpm-build gcc make pkgconf-pkg-config ${SYSTEM_REQUIRES}
 {%- elif cookiecutter.vendor_base == "suse" -%}


### PR DESCRIPTION
## Changes
- If the `SYSTEM_REQUIRES` list is updated long after the image is created, then the attempt to install the new requirements may use an out-dated apt cache and will likely error during the install.
- Ensures `apt-get update` is always run before an apt install.
- The other package managers are more sane and only attempt an install with an up-to-date cache.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct