### PR TITLE
Disable SDL from attempting to connect to audio

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -3,9 +3,10 @@ FROM {{ cookiecutter.docker_base_image }}
 # Set the working directory
 WORKDIR /app
 
-# Disable pip's warnings
+# Disable pip's warnings and SDL audio
 ENV PIP_ROOT_USER_ACTION=ignore \
-    PIP_NO_WARN_SCRIPT_LOCATION=0
+    PIP_NO_WARN_SCRIPT_LOCATION=0 \
+    SDL_AUDIODRIVER=dummy
 
 {% if cookiecutter.vendor_base == "debian" -%}
 # Run apt non-interactively; use ARG so this only applies while building the image


### PR DESCRIPTION
Anytime one of the SDL based GUI toolkits tries to connect to audio inside Docker, it's going to fail....so, just disable it inside the container.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct