### PR TITLE
Change the order of installation for devel-basis under SuSE

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -50,8 +50,9 @@ RUN apt-get update -y && \
 {%- elif cookiecutter.vendor_base == "rhel" -%}
 RUN dnf install -y gcc make rpm-build pkgconf-pkg-config git ${SYSTEM_REQUIRES}
 {%- elif cookiecutter.vendor_base == "suse" -%}
-RUN zypper install -y -t pattern devel_basis
 RUN zypper install -y rpm-build pkgconf-pkg-config git ${SYSTEM_REQUIRES}
+# devel_basis must be installed *after* rpm-build to prevent installing busybox
+RUN zypper install -y -t pattern devel_basis
 {%- elif cookiecutter.vendor_base == "arch" -%}
 RUN pacman -Syu --noconfirm base-devel pkgconf git ${SYSTEM_REQUIRES}
 {%- endif %}


### PR DESCRIPTION
In the Dependabot overnights, we started seeing failures because the installation of `rpm-build` was incompatible with the existing install of `busybox-diffutils`. `busybox-diffutils` is installed by the `devel_basis` template.

However if you install `devel_basis` *after* installing `rpm-build`, busybox et al appears to be committed from the installation list.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
