### PR TITLE
Ignore any installed packages when installing pip et al

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -37,9 +37,12 @@ RUN pacman -Syu --noconfirm \
 
 # Upgrade pip et alia
 # PEP 668 allows distros to mark the system Python as "externally managed". With this
-# configuration, `pip install` will error when using the system Python. This setting
-# ignores this configuration in the distro and allows for installing the latest pip.
+# configuration in the distro, `pip install` will error when using the system Python.
+# PIP_BREAK_SYSTEM_PACKAGES allows pip to ignore this safeguard and when combined with
+# PIP_IGNORE_INSTALLED, pip will altogether ignore the distro-managed versions of these
+# packages and install the latest versions to /usr/local/.
 RUN PIP_BREAK_SYSTEM_PACKAGES=1 \
+    PIP_IGNORE_INSTALLED=1 \
     python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # As root, install system packages required by app


### PR DESCRIPTION
## Changes
- Closes https://github.com/beeware/briefcase/issues/1738

## Notes
- I used `PIP_IGNORE_INSTALLED` instead of `--ignore-installed` just in case the available `pip` is older and `--ignore-installed` might not be available

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct