### PR TITLE
Ensure that sys.executable returns the executable name

### DIFF
--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     // Establish where the executable is located;
     // other application paths will be computed relative to this location
     exe_path = realpath("/proc/self/exe", NULL);
-    bin_path = dirname(exe_path);
+    bin_path = dirname(strdup(exe_path));
     install_path = dirname(bin_path);
     printf("Install path: %s\n", install_path);
 
@@ -63,6 +63,14 @@ int main(int argc, char *argv[]) {
     status = Py_PreInitialize(&preconfig);
     if (PyStatus_Exception(status)) {
         // crash_dialog("Unable to pre-initialize Python interpreter: %s", status.err_msg, nil]);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // Set the executable name to match the actual executable
+    status = PyConfig_SetBytesString(&config, &config.executable, exe_path);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set executable name: %s", status.err_msg);
         PyConfig_Clear(&config);
         Py_ExitStatusException(status);
     }


### PR DESCRIPTION
The current stub binary used in a packaged system app returns `sys.executable` as `python3`. This is neither correct, nor helpful.

The equivalent change isn't needed on macOS because macOS has special handling that overrides the config setting.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
