### PR TITLE
Ensure the system package for setuptools is installed on Arch

### DIFF
--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -32,7 +32,8 @@ RUN zypper install -y \
 # Install System python
 RUN pacman -Syu --noconfirm \
     python{{ cookiecutter.python_version|py_tag }} \
-    python-pip
+    python-pip \
+    python-setuptools
 {%- endif %}
 
 # Upgrade pip et alia

--- a/{{ cookiecutter.format }}/Dockerfile
+++ b/{{ cookiecutter.format }}/Dockerfile
@@ -26,14 +26,14 @@ RUN dnf install -y \
 {%- elif cookiecutter.vendor_base == "suse" -%}
 # Install System python
 RUN zypper install -y \
-    python{{ cookiecutter.python_version|py_tag }}-devel \
-    python{{ cookiecutter.python_version|py_tag }}-pip
+      python{{ cookiecutter.python_version|py_tag }}-devel \
+      python{{ cookiecutter.python_version|py_tag }}-pip
 {%- elif cookiecutter.vendor_base == "arch" -%}
 # Install System python
 RUN pacman -Syu --noconfirm \
-    python{{ cookiecutter.python_version|py_tag }} \
-    python-pip \
-    python-setuptools
+      python{{ cookiecutter.python_version|py_tag }} \
+      python-pip \
+      python-setuptools
 {%- endif %}
 
 # Upgrade pip et alia


### PR DESCRIPTION
The recent update to use PIP_BREAK_SYSTEM_PACKAGES appears to have [caused a problem on Arch](https://github.com/beeware/briefcase/actions/runs/8918302073/job/24493177612).

We use PIP_BREAK_SYSTEM_PACKAGES to install setuptools. However, Arch then tries to install `python-setuptools` as a an optional build component of the python package. It then complains because it would need to overwrite existing files.

This change installs python-setuptools as part of the initial Python install, which means that the python install can overwrite the setuptools install, rather than the other way around.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
