### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,7 +16,7 @@
     "console_app": false,
     "briefcase_version": "0.3.X",
     "python_version": "3.X.0",
-    "docker_base_image": "ubuntu:20.04",
+    "docker_base_image": "ubuntu:22.04",
     "vendor_base": "debian",
     "dockerfile_extra_content": "",
     "use_non_root_user": true,


### PR DESCRIPTION
## Changes
- Drop Python 3.8 as Briefcase's `main` branch no longer supports it

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
