### PR TITLE
Allow for runpy returning non-integer results.

### DIFF
--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -236,6 +236,10 @@ int main(int argc, char *argv[]) {
             if (systemExit_code == NULL) {
                 debug_log("Could not determine exit code\n");
                 ret = -10;
+            } else if (systemExit_code == Py_None) {
+                // SystemExit with a code of None; documented as a return code
+                // of 0.
+                ret = 0;
             } else if (PyLong_Check(systemExit_code)) {
                 // SystemExit with error code
                 ret = (int) PyLong_AsLong(systemExit_code);

--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -236,9 +236,17 @@ int main(int argc, char *argv[]) {
             if (systemExit_code == NULL) {
                 debug_log("Could not determine exit code\n");
                 ret = -10;
-            }
-            else {
+            } else if (PyLong_Check(systemExit_code)) {
+                // SystemExit with error code
                 ret = (int) PyLong_AsLong(systemExit_code);
+            } else {
+                // Convert exit code to a string. This is required by runpy._error
+                ret = -11;
+                printf("---------------------------------------------------------------------------\n");
+                printf("Application quit abnormally!\n");
+
+                // Display exit message in the crash dialog.
+                PyObject_Print(systemExit_code, stdout, Py_PRINT_RAW);
             }
         } else {
             // Non-SystemExit; likely an uncaught exception

--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -240,25 +240,22 @@ int main(int argc, char *argv[]) {
                 // SystemExit with error code
                 ret = (int) PyLong_AsLong(systemExit_code);
             } else {
-                // Convert exit code to a string. This is required by runpy._error
+                // SystemExit with a string for an error code.
                 ret = -11;
-                printf("---------------------------------------------------------------------------\n");
-                printf("Application quit abnormally!\n");
-
-                // Display exit message in the crash dialog.
-                PyObject_Print(systemExit_code, stdout, Py_PRINT_RAW);
             }
         } else {
             // Non-SystemExit; likely an uncaught exception
             ret = -6;
+        }
+
+        if (ret != 0) {
             printf("---------------------------------------------------------------------------\n");
             printf("Application quit abnormally!\n");
 
-            // Restore the error state of the interpreter.
+            // Restore the error state of the interpreter, and print exception
+            // to stderr. In the case of a SystemExit, this will exit with a
+            // status of 1.
             PyErr_Restore(exc_type, exc_value, exc_traceback);
-
-            // Print exception to stderr.
-            // In case of SystemExit, this will call exit()
             PyErr_Print();
         }
     }

--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -241,17 +241,16 @@ int main(int argc, char *argv[]) {
                 ret = (int) PyLong_AsLong(systemExit_code);
             } else {
                 // SystemExit with a string for an error code.
-                ret = -11;
+                ret = 1;
             }
         } else {
             // Non-SystemExit; likely an uncaught exception
+            printf("---------------------------------------------------------------------------\n");
+            printf("Application quit abnormally!\n");
             ret = -6;
         }
 
         if (ret != 0) {
-            printf("---------------------------------------------------------------------------\n");
-            printf("Application quit abnormally!\n");
-
             // Restore the error state of the interpreter, and print exception
             // to stderr. In the case of a SystemExit, this will exit with a
             // status of 1.


### PR DESCRIPTION
Fixes #34.

Implements the same fix as https://github.com/beeware/briefcase-macOS-Xcode-template/pull/65.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
