### PR TITLE
Drop Python 3.9, add 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "system", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "system", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        # Pygame hasn't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pygame
+            runner-os: "ubuntu-24.04"
+          - python-version: "3.14"
+            framework: pygame
+            runner-os: "ubuntu-24.04-arm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,14 @@ jobs:
         python-version: [ "system", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
-        # Pygame hasn't published 3.14 wheels yet.
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
         exclude:
+          - python-version: "3.14"
+            framework: pyside6
+            runner-os: "ubuntu-24.04"
+          - python-version: "3.14"
+            framework: pyside6
+            runner-os: "ubuntu-24.04-arm"
           - python-version: "3.14"
             framework: pygame
             runner-os: "ubuntu-24.04"

--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -56,6 +56,8 @@ int main(int argc, char *argv[]) {
     // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
     // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
     preconfig.utf8_mode = 1;
+    // Ensure the locale is set (isolated interpreters won't by default)
+    preconfig.configure_locale = 1;
     // Don't buffer stdio. We want output to appears in the log immediately
     config.buffered_stdio = 0;
     // Don't write bytecode; we can't modify the app bundle


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

Also includes the fix for locale initialization (see beeware/briefcase-iOS-Xcode-template#57).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
