### PR TITLE
Add signal handler initialization.

### DIFF
--- a/{{ cookiecutter.format }}/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/bootstrap/main.c
@@ -63,6 +63,8 @@ int main(int argc, char *argv[]) {
     // Don't write bytecode; we can't modify the app bundle
     // after it has been signed.
     config.write_bytecode = 0;
+    // Ensure that signal handlers are installed
+    config.install_signal_handlers = 1;
     // Isolated apps need to set the full PYTHONPATH manually.
     config.module_search_paths_set = 1;
     // We're using the system Python's stdlib; however, we don't want anything


### PR DESCRIPTION
Ensure that the embedded Python interpreter in the stub app enables Python's default signal handlers on startup.

Refs ankitects/anki#5369
Refs beeware/briefcase#3014.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
